### PR TITLE
docs: update clone URLs and project name after org move

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ SpectraX wraps [MediaMTX](https://github.com/bluenviron/mediamtx), a powerful RT
 
 ```bash
 # Clone the repository
-git clone https://github.com/soos3d/SpectraX.git
+git clone https://github.com/SpectraCoreX/SpectraX.git
 cd SpectraX
 
 # Create virtual environment

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -552,7 +552,7 @@ for detection, tracker_id in zip(tracked, tracked.tracker_id):
 
 ```bash
 # Clone repository
-git clone https://github.com/soos3d/SpectraX.git
+git clone https://github.com/SpectraCoreX/SpectraX.git
 cd SpectraX
 
 # Create virtual environment

--- a/video-feed/requirements.txt
+++ b/video-feed/requirements.txt
@@ -1,4 +1,4 @@
-# SentriX Surveillance System - Core Dependencies
+# SpectraX Surveillance System - Core Dependencies
 # Optimized requirements file (cleaned up 2025-10-02)
 
 # ============================================================

--- a/video-feed/tests/README.md
+++ b/video-feed/tests/README.md
@@ -1,6 +1,6 @@
-# SentriX Test Suite
+# SpectraX Test Suite
 
-This directory contains all tests for the SentriX surveillance system.
+This directory contains all tests for the SpectraX surveillance system.
 
 ## Test Organization
 

--- a/video-feed/tests/__init__.py
+++ b/video-feed/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Test suite for SentriX surveillance system."""
+"""Test suite for SpectraX surveillance system."""


### PR DESCRIPTION
The repo moved to the SpectraCoreX org, but two doc surfaces still pointed at the old home and three files carried the project's old name. A second commit makes the CV stack attribution visible where it's used, not just in the closing credits.

## Changes
- `README.md`, `docs/ARCHITECTURE.md`: clone URL `soos3d/SpectraX` → `SpectraCoreX/SpectraX`
- `video-feed/requirements.txt`, `video-feed/tests/README.md`, `video-feed/tests/__init__.py`: `SentriX` → `SpectraX`
- `README.md`: name Ultralytics YOLOv8 and Roboflow supervision in the intro and in the detection/tracking feature bullets (previously credited only in Acknowledgments)

## Test plan
- Docs/comments only, no code paths touched
- `grep -rn 'soos3d/SpectraX\|SentriX'` returns nothing